### PR TITLE
Update README.md, fix possible naming collisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ docker run --name phoebe  \
 ### Build the project jar
 
 ```shell
-export GIT_REPO_FOLDER='/Users/iliyan/work/git/codbex-phoebe'
+export GIT_REPO_FOLDER='<path-to-the-git-repo>'
 
 cd $GIT_REPO_FOLDER
 
@@ -105,7 +105,7 @@ mvn -T 1C clean install -P quick-build
 __Prerequisites:__ [Build the project jar](#build-the-project-jar)
 
   ```shell
-  export GIT_REPO_FOLDER='/Users/iliyan/work/git/codbex-phoebe'
+  export GIT_REPO_FOLDER='<path-to-the-git-repo>'
 
   cd "$GIT_REPO_FOLDER/application"
   
@@ -127,7 +127,7 @@ __Prerequisites:__ [Build the project jar](#build-the-project-jar)
 
 - Start Airflow locally
     ```shell
-    export GIT_REPO_FOLDER='/Users/iliyan/work/git/codbex-phoebe'
+    export GIT_REPO_FOLDER='<path-to-the-git-repo>'
     cd "$GIT_REPO_FOLDER"
   
     export AIRFLOW_WORK_DIR="$HOME/airflow_work"
@@ -158,7 +158,7 @@ __Prerequisites:__ [Build the project jar](#build-the-project-jar)
 
 - Start the application
     ```shell
-    export GIT_REPO_FOLDER='/Users/iliyan/work/git/codbex-phoebe'
+    export GIT_REPO_FOLDER='<path-to-the-git-repo>'
     cd "$GIT_REPO_FOLDER"
   
     export PHOEBE_AIRFLOW_WORK_DIR="$AIRFLOW_WORK_DIR"
@@ -171,7 +171,7 @@ __Prerequisites:__ [Build the project jar](#build-the-project-jar)
 
 - Start the application **in debug** with debug port `8000`
     ```shell
-    export GIT_REPO_FOLDER='/Users/iliyan/work/git/codbex-phoebe'
+    export GIT_REPO_FOLDER='<path-to-the-git-repo>'
     cd "$GIT_REPO_FOLDER"
   
     export PHOEBE_AIRFLOW_WORK_DIR="$AIRFLOW_WORK_DIR"
@@ -190,7 +190,7 @@ __Prerequisites:__ [Build the project jar](#build-the-project-jar)
 __Prerequisites:__ [Build the project jar](#build-the-project-jar)
 
 ```shell
-export GIT_REPO_FOLDER='/Users/iliyan/work/git/codbex-phoebe'
+export GIT_REPO_FOLDER='<path-to-the-git-repo>'
 export IMAGE='codbex-phoebe:dev'
 export GITHUB_USERNAME='<your-github-user>'
 
@@ -230,7 +230,7 @@ docker pull "ghcr.io/$GITHUB_USERNAME/$IMAGE" --platform linux/arm64
 ### Run unit tests
 
 ```shell
-export GIT_REPO_FOLDER='/Users/iliyan/work/git/codbex-phoebe'
+export GIT_REPO_FOLDER='<path-to-the-git-repo>'
 
 cd "$GIT_REPO_FOLDER"
 mvn clean install -P unit-tests
@@ -241,7 +241,7 @@ mvn clean install -P unit-tests
 ### Run integration tests
 
 ```shell
-export GIT_REPO_FOLDER='/Users/iliyan/work/git/codbex-phoebe'
+export GIT_REPO_FOLDER='<path-to-the-git-repo>'
 
 cd "$GIT_REPO_FOLDER"
 mvn clean install -P integration-tests
@@ -252,7 +252,7 @@ mvn clean install -P integration-tests
 ### Run all tests
 
 ```shell
-export GIT_REPO_FOLDER='/Users/iliyan/work/git/codbex-phoebe'
+export GIT_REPO_FOLDER='<path-to-the-git-repo>'
 
 cd "$GIT_REPO_FOLDER"
 mvn clean install -P tests
@@ -263,7 +263,7 @@ mvn clean install -P tests
 ### Format the code
 
 ```shell
-export GIT_REPO_FOLDER='/Users/iliyan/work/git/codbex-phoebe'
+export GIT_REPO_FOLDER='<path-to-the-git-repo>'
 
 cd "$GIT_REPO_FOLDER"
 mvn verify -P format

--- a/application/Dockerfile
+++ b/application/Dockerfile
@@ -31,7 +31,7 @@ RUN mkdir -p /opt/airflow/codbex && \
 USER airflow
 
 # Copy your Spring Boot application JAR into the container
-COPY target/codbex-phoebe-[0-9]*.jar /opt/airflow/codbex/codbex-phoebe.jar
+COPY ./target/codbex-phoebe-[0-9]*.jar /opt/airflow/codbex/codbex-phoebe.jar
 
 # Expose 80 for the Java app only
 EXPOSE 80

--- a/application/Dockerfile
+++ b/application/Dockerfile
@@ -31,7 +31,7 @@ RUN mkdir -p /opt/airflow/codbex && \
 USER airflow
 
 # Copy your Spring Boot application JAR into the container
-COPY ./target/*.jar /opt/airflow/codbex/application.jar
+COPY target/codbex-phoebe-[0-9]*.jar /opt/airflow/codbex/codbex-phoebe.jar
 
 # Expose 80 for the Java app only
 EXPOSE 80

--- a/application/pom.xml
+++ b/application/pom.xml
@@ -412,6 +412,10 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 

--- a/application/pom.xml
+++ b/application/pom.xml
@@ -409,8 +409,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-maven-plugin</artifactId>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.springframework.boot</groupId>

--- a/application/start.sh
+++ b/application/start.sh
@@ -16,4 +16,4 @@ echo "Starting java application..."
 java --add-opens=java.base/java.lang=ALL-UNNAMED \
      --add-opens=java.base/java.lang.reflect=ALL-UNNAMED \
      --add-opens=java.base/java.nio=ALL-UNNAMED \
-     -jar ./application.jar
+     -jar ./codbex-phoebe.jar

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codbex.platform</groupId>
         <artifactId>codbex-platform-parent</artifactId>
-        <version>10.6.50</version>
+        <version>11.1.2</version>
     </parent>
 
     <name>codbex - phoebe - parent</name>


### PR DESCRIPTION
Update README.md, fix possible naming collisions when starting with java -jar and during the Docker build