### PR TITLE
Make proxy integration tests hermetic (#178)

### DIFF
--- a/integration-tests/src/test/java/com/codbex/phoebe/integration/tests/AirflowPerspectiveIT.java
+++ b/integration-tests/src/test/java/com/codbex/phoebe/integration/tests/AirflowPerspectiveIT.java
@@ -12,19 +12,34 @@ package com.codbex.phoebe.integration.tests;
 
 import com.codbex.phoebe.cfg.AppConfig;
 import org.eclipse.dirigible.tests.framework.browser.HtmlElementType;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 
 class AirflowPerspectiveIT extends PhoebeIntegrationTest {
 
+    private static final String AIRFLOW_TITLE = "Apache Airflow";
+
+    // A local stub stands in for the Airflow instance so the test does not depend on an external
+    // host. The URL must be configured before the Spring context (and the proxy beans) start, hence
+    // the static initializer.
+    private static final LocalHttpStub AIRFLOW_STUB =
+            LocalHttpStub.startServingHtml("<!DOCTYPE html><html><head><title>" + AIRFLOW_TITLE + "</title></head>" //
+                    + "<body><h2>" + AIRFLOW_TITLE + "</h2></body></html>");
+
     static {
-        AppConfig.AIRFLOW_URL.setValue("http://httpbin.org");
+        AppConfig.AIRFLOW_URL.setValue(AIRFLOW_STUB.baseUrl());
+    }
+
+    @AfterAll
+    static void stopStub() {
+        AIRFLOW_STUB.stop();
     }
 
     @Test
     void testPerspective() {
-        // expected to open https://httpbin.org
+        // the perspective iframes the proxied Airflow UI served by the local stub
         ide.openPath("/services/web/perspective-airflow/index.html");
 
-        browser.assertElementExistsByTypeAndContainsText(HtmlElementType.HEADER2, "httpbin.org");
+        browser.assertElementExistsByTypeAndContainsText(HtmlElementType.HEADER2, AIRFLOW_TITLE);
     }
 }

--- a/integration-tests/src/test/java/com/codbex/phoebe/integration/tests/LocalHttpStub.java
+++ b/integration-tests/src/test/java/com/codbex/phoebe/integration/tests/LocalHttpStub.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package com.codbex.phoebe.integration.tests;
+
+import com.sun.net.httpserver.HttpServer;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * A minimal, self-contained HTTP server backed by the JDK (no external dependency) used as the
+ * upstream "Airflow" target in proxy integration tests. It serves a fixed HTML body for every
+ * request on an OS-assigned ephemeral port, which makes the proxy tests hermetic instead of relying
+ * on flaky external hosts (e.g. httpbin.org).
+ */
+final class LocalHttpStub {
+
+    private final HttpServer server;
+    private final String baseUrl;
+
+    private LocalHttpStub(HttpServer server) {
+        this.server = server;
+        this.baseUrl = "http://localhost:" + server.getAddress()
+                                                   .getPort();
+    }
+
+    /**
+     * Starts a stub server that replies to every request with the given HTML body.
+     *
+     * @param htmlBody the response body served as {@code text/html}
+     * @return the started stub; the caller is responsible for {@link #stop()}
+     */
+    static LocalHttpStub startServingHtml(String htmlBody) {
+        try {
+            HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+            byte[] body = htmlBody.getBytes(StandardCharsets.UTF_8);
+            server.createContext("/", exchange -> {
+                exchange.getResponseHeaders()
+                        .set("Content-Type", "text/html; charset=utf-8");
+                exchange.sendResponseHeaders(200, body.length);
+                try (OutputStream responseBody = exchange.getResponseBody()) {
+                    responseBody.write(body);
+                }
+            });
+            server.start();
+            return new LocalHttpStub(server);
+        } catch (IOException ex) {
+            throw new IllegalStateException("Failed to start local HTTP stub server", ex);
+        }
+    }
+
+    /**
+     * @return the base URL (scheme, host and port) the stub is listening on
+     */
+    String baseUrl() {
+        return baseUrl;
+    }
+
+    void stop() {
+        server.stop(0);
+    }
+}

--- a/integration-tests/src/test/java/com/codbex/phoebe/integration/tests/ProxyIT.java
+++ b/integration-tests/src/test/java/com/codbex/phoebe/integration/tests/ProxyIT.java
@@ -12,30 +12,42 @@ package com.codbex.phoebe.integration.tests;
 
 import com.codbex.phoebe.cfg.AppConfig;
 import org.eclipse.dirigible.tests.framework.restassured.RestAssuredExecutor;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import static io.restassured.RestAssured.given;
-import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.containsString;
 
 class ProxyIT extends PhoebeIntegrationTest {
 
     private static final String AIRFLOW_PROXY_PATH = "/services/airflow";
 
+    // The stub returns a root-relative link; the proxy is expected to rewrite it so it stays within
+    // the "/services/airflow" prefix when the UI is served behind the proxy.
+    private static final LocalHttpStub AIRFLOW_STUB =
+            LocalHttpStub.startServingHtml("<html><body><a href=\"/airflow/home\">home</a></body></html>");
+
     static {
-        AppConfig.AIRFLOW_URL.setValue("https://api.ipify.org");
+        AppConfig.AIRFLOW_URL.setValue(AIRFLOW_STUB.baseUrl());
     }
 
     @Autowired
     private RestAssuredExecutor restAssuredExecutor;
 
+    @AfterAll
+    static void stopStub() {
+        AIRFLOW_STUB.stop();
+    }
+
     @Test
     void textProxyPath() {
-        // expected to open https://api.ipify.org?format=json
+        // the proxy forwards to the local stub and rewrites the root-relative link in the response
+        // body from "/airflow/home" to "/services/airflow/airflow/home"
         restAssuredExecutor.execute(() -> given().when()
-                                                 .get(AIRFLOW_PROXY_PATH + "?format=json")
+                                                 .get(AIRFLOW_PROXY_PATH + "/home")
                                                  .then()
                                                  .statusCode(200)
-                                                 .body("ip", notNullValue()));
+                                                 .body(containsString("href=\"" + AIRFLOW_PROXY_PATH + "/airflow/home\"")));
     }
 }


### PR DESCRIPTION
Closes #178.

## Problem

`AirflowPerspectiveIT` and `ProxyIT` configured the Airflow proxy to forward to **external hosts** (`httpbin.org` and `api.ipify.org`). Whenever those services were slow, rate-limited, or temporarily down, the tests failed — producing red `pull-request / integration-tests` checks on changes that had nothing to do with the proxy. This is exactly what happened on #177 (the `13.1.0 → 13.2.0` parent bump): the proxied iframe rendered httpbin.org's transient **`503 Service Temporarily Unavailable`** page, and a plain re-run went green once the upstream recovered.

## Change

- **`LocalHttpStub`** — a minimal HTTP server backed by the JDK (`com.sun.net.httpserver`, no new dependency) that serves a fixed `text/html` body on an OS-assigned ephemeral port.
- **`AirflowPerspectiveIT`** — points `PHOEBE_AIRFLOW_URL` at the stub and asserts the stubbed `<h2>` renders inside the proxied iframe. No external host.
- **`ProxyIT`** — points at the stub, which returns a root-relative link (`/airflow/home`), and asserts the proxy rewrites it to `/services/airflow/airflow/home` — verifying the rewriting behavior end-to-end against a controlled response instead of relying on `api.ipify.org`.

The stub URL is set in a static initializer (before the Spring context / proxy beans start, matching the previous pattern) and the server is stopped in `@AfterAll`.

The detailed body-rewriting rules remain covered by the existing `TextResponseBodyRewriterTest` unit test.

## Verification

Both tests pass locally and reach no external network host:

```
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0 -- in com.codbex.phoebe.integration.tests.ProxyIT
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0 -- in com.codbex.phoebe.integration.tests.AirflowPerspectiveIT
[INFO] BUILD SUCCESS
```

Log line confirming the proxy targets the local stub: `Configuring Airflow proxy for path [/services/airflow/**] to URL [http://localhost:52246]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
