### PR TITLE
Fix Airflow proxy 500 on JS assets containing '$'/'\' (Airflow 3.2.2)

### DIFF
--- a/application/src/main/java/com/codbex/phoebe/proxy/TextResponseBodyRewriter.java
+++ b/application/src/main/java/com/codbex/phoebe/proxy/TextResponseBodyRewriter.java
@@ -111,7 +111,9 @@ class TextResponseBodyRewriter implements BodyFilterFunctions.RewriteResponseFun
 
             String replacement = newAirflowUrl + (extraPath != null ? "/" + extraPath : "");
 
-            matcher.appendReplacement(result, replacement);
+            // quoteReplacement escapes any '$' or '\' in the matched path (common in minified JS bundles)
+            // so they are not interpreted as group references by appendReplacement
+            matcher.appendReplacement(result, Matcher.quoteReplacement(replacement));
         }
         matcher.appendTail(result);
 
@@ -131,7 +133,7 @@ class TextResponseBodyRewriter implements BodyFilterFunctions.RewriteResponseFun
             String updatedPath = "/services/airflow" + decodedPath;
             String reEncodedPath = URLEncoder.encode(updatedPath, StandardCharsets.UTF_8);
 
-            matcher.appendReplacement(result, paramName + reEncodedPath);
+            matcher.appendReplacement(result, Matcher.quoteReplacement(paramName + reEncodedPath));
         }
         matcher.appendTail(result);
 

--- a/application/src/test/java/com/codbex/phoebe/proxy/TextResponseBodyRewriterTest.java
+++ b/application/src/test/java/com/codbex/phoebe/proxy/TextResponseBodyRewriterTest.java
@@ -129,6 +129,21 @@ class TextResponseBodyRewriterTest {
     }
 
     @Test
+    void rewriteBody_shouldNotFail_whenAirflowUrlIsFollowedByDollarOrBackslash() {
+        // minified JS bundles (e.g. Airflow's static assets) may contain '$' or '\' right after the
+        // Airflow URL; these are special chars for Matcher.appendReplacement and previously caused
+        // an IllegalArgumentException: Illegal group reference -> HTTP 500
+        byte[] body = "var a=\"http://localhost:8080/path/$1\\foo\";".getBytes(StandardCharsets.UTF_8);
+        String expectedBody = "var a=\"http://localhost:8080/services/airflow/path/$1\\foo\";";
+
+        when(request.uri()).thenReturn(URI.create("http://localhost:8080/services/airflow"));
+
+        String result = rewriter.rewriteBody(request, body);
+
+        assertEquals(expectedBody, result);
+    }
+
+    @Test
     void rewriteBody_shouldNotReplaceAirflowUrl_whenHostHeaderIsMissing() {
         byte[] body = "<html><body>http://old-airflow-url</body></html>".getBytes(StandardCharsets.UTF_8);
         String expectedBody = "<html><body>http://old-airflow-url</body></html>";


### PR DESCRIPTION
## Problem

After bumping `apache/airflow` from 3.0.2 to 3.2.2 (#1f987d7), opening the Airflow perspective fails: the request for static JS assets such as `/services/airflow/static/assets/index-C6RXW4nO.js` returns HTTP **500**.

The container log shows:

```
java.lang.IllegalArgumentException: Illegal group reference
    at java.util.regex.Matcher.appendExpandedReplacement(Matcher.java:1113)
    at java.util.regex.Matcher.appendReplacement(Matcher.java:951)
    at com.codbex.phoebe.proxy.TextResponseBodyRewriter.rewriteFullURLs(TextResponseBodyRewriter.java:114)
```

## Root cause

`TextResponseBodyRewriter.rewriteFullURLs` builds a replacement string from the matched path and feeds it to `Matcher.appendReplacement`. That method interprets `$` as a capture-group reference and `\` as an escape character. The new Airflow 3.2.2 minified JS bundle contains the Airflow URL immediately followed by paths that include `$` / `\` (common in minified JS), so an unescaped `$`/`\` in the computed replacement throws `IllegalArgumentException: Illegal group reference`, which surfaces as a 500 and breaks the embedded UI.

## Fix

Escape the replacement strings with `Matcher.quoteReplacement(...)` in `rewriteFullURLs` (the failing path) and, defensively, in `rewriteEncodedQueryParams`. Added a regression test (`rewriteBody_shouldNotFail_whenAirflowUrlIsFollowedByDollarOrBackslash`).

## Testing

`mvn test -P unit-tests -Dtest=TextResponseBodyRewriterTest -pl application` — 6 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)